### PR TITLE
Fix selection not working

### DIFF
--- a/consult-git-log-grep.el
+++ b/consult-git-log-grep.el
@@ -78,7 +78,7 @@
                              (datetime . ,datetime))
                            msg)
         (add-text-properties 0 (length suffix) '(invisible t consult-strip t) suffix)
-        (list (concat msg suffix))))))
+        (list (cons (concat msg suffix) sha))))))
 
 
 (defun consult-git-log-grep--builder (input)
@@ -130,7 +130,7 @@
                       :initial initial
                       :add-history (thing-at-point 'symbol)
                       :history '(:input consult-git-log-grep--history))))
-    (funcall consult-git-log-grep-open-function (car result))))
+    (funcall consult-git-log-grep-open-function result)))
 
 (provide 'consult-git-log-grep)
 ;;; consult-git-log-grep.el ends here


### PR DESCRIPTION
There are two issues. (1) The fix for duplicate commit messages (https://github.com/ghosty141/consult-git-log-grep/commit/2dbedc0efc90c8a0311c9f2244596fe1ee3eddd4) changed the result to return a list, but consult--lookup-cdr requires an association list, so the fix is to put the result inside a list.

(2) The result returned by consult--read is no longer a list, so the car is not needed.